### PR TITLE
Add BlockheightCheck to restart NodeLeader if blockheight is not advancing

### DIFF
--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -82,6 +82,8 @@ class NodeLeader:
 
     NodeCount = 0
 
+    CurrentBlockheight = 0
+
     ServiceEnabled = False
 
     peer_check_loop = None
@@ -92,6 +94,9 @@ class NodeLeader:
 
     memcheck_loop = None
     memcheck_loop_deferred = None
+
+    blockheight_loop = None
+    blockheight_loop_deferred = None
 
     task_handles = {}
 
@@ -167,6 +172,19 @@ class NodeLeader:
         if cancel and self.memcheck_loop_deferred:
             self.memcheck_loop_deferred.cancel()
 
+    def start_blockheight_loop(self):
+        self.stop_blockheight_loop()
+        self.CurrentBlockheight = BC.Default().Height
+        self.blockheight_loop = task.LoopingCall(self.BlockheightCheck)
+        self.blockheight_loop_deferred = self.blockheight_loop.start(60, now=False)
+        self.blockheight_loop_deferred.addErrback(self.OnBlockheightcheckError)
+
+    def stop_blockheight_loop(self, cancel=True):
+        if self.blockheight_loop and self.blockheight_loop.running:
+            self.blockheight_loop.stop()
+        if cancel and self.blockheight_loop_deferred:
+            self.blockheight_loop_deferred.cancel()    
+
     def Setup(self):
         """
         Initialize the local node.
@@ -185,10 +203,12 @@ class NodeLeader:
         self.stop_peer_check_loop()
         self.stop_check_bcr_loop()
         self.stop_memcheck_loop()
+        self.stop_blockheight_loop()
 
         self.peer_check_loop_deferred = None
         self.check_bcr_loop_deferred = None
         self.memcheck_loop_deferred = None
+        self.blockheight_loop_deferred = None
 
         if len(self.Peers) == 0:
             # preserve any addresses we know because the peers in the seedlist might have gone bad and then we can't receive new addresses anymore
@@ -245,10 +265,11 @@ class NodeLeader:
                 setupConnDeferred.addErrback(self.OnSetupConnectionErr)
                 start_delay += 1
 
-        logger.debug("Starting up nodeleader: starting peer and mempool check loops")
+        logger.debug("Starting up nodeleader: starting peer, mempool, and blockheight check loops")
         # check in on peers every 10 seconds
         self.start_peer_check_loop()
         self.start_memcheck_loop()
+        self.start_blockheight_loop()
 
         if settings.ACCEPT_INCOMING_PEERS:
             logger.debug(f"Starting up nodeleader: setting up listen server on port: '{settings.NODE_PORT}")
@@ -306,6 +327,9 @@ class NodeLeader:
         self.stop_memcheck_loop()
         self.memcheck_loop_deferred = None
 
+        self.stop_blockheight_loop()
+        self.blockheight_loop_deferred = None
+
         for p in self.Peers:
             p.Disconnect()
 
@@ -360,6 +384,11 @@ class NodeLeader:
         if type(err.value) == CancelledError:
             return
         logger.debug("Error on Memcheck check %s " % err)
+
+    def OnBlockheightcheckError(self, err):
+        if type(err.value) == CancelledError:
+            return
+        logger.debug("Error on Blockheight check loop %s " % err)
 
     def PeerCheckLoop(self):
         # often times things will get stuck on 1 peer so
@@ -567,3 +596,11 @@ class NodeLeader:
             res = self.RemoveTransaction(tx)
             if res:
                 logger.debug("found tx 0x%s on the blockchain ...removed from mempool" % tx.Hash)
+
+    def BlockheightCheck(self):
+        """
+        Checks the current blockheight and restarts NodeLeader if not advancing
+        """
+        if self.CurrentBlockheight == BC.Default().Height:
+            logger.debug("Blockheight is not advancing ...restarting NodeLeader")
+            self.Restart()

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -604,3 +604,5 @@ class NodeLeader:
         if self.CurrentBlockheight == BC.Default().Height:
             logger.debug("Blockheight is not advancing ...restarting NodeLeader")
             self.Restart()
+        else:
+            self.CurrentBlockheight = BC.Default().Height


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
See https://github.com/CityOfZion/neo-python/pull/723#issuecomment-440842284

NodeLeader is continuing to run when blockheight is not advancing.
This PR adds CheckBlockheight which restarts NodeLeader if blockheight has not advanced after 60 seconds.

**How did you solve this problem?**
Trial and Error

**How did you make sure your solution works?**
Personal Testing

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
- [ ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
