### PR TITLE
fix `show state` [2]

### DIFF
--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -13,6 +13,7 @@ from neo.logging import log_manager
 from neo.Prompt.PromptPrinter import prompt_print as print
 from neo.Network.p2pservice import NetworkService
 from neo.Network.neonetwork.network.nodemanager import NodeManager
+from neo.Network.neonetwork.network.syncmanager import SyncManager
 import json
 import asyncio
 
@@ -238,8 +239,10 @@ class CommandShowState(CommandBase):
             bpm = diff / mins
             tps = Blockchain.Default().TXProcessed / secs
 
+        syncmngr = SyncManager()
+
         out = "Progress: %s / %s\n" % (height, headers)
-        out += "Block-cache length %s\n" % Blockchain.Default().BlockCacheCount
+        out += "Block-cache length %s\n" % len(syncmngr.block_cache)
         out += "Blocks since program start %s\n" % diff
         out += "Time elapsed %s mins\n" % mins
         out += "Blocks per min %s \n" % bpm

--- a/neo/Prompt/Commands/tests/test_show_commands.py
+++ b/neo/Prompt/Commands/tests/test_show_commands.py
@@ -7,9 +7,11 @@ from neo.Prompt.PromptData import PromptData
 from neo.bin.prompt import PromptInterface
 from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
-from mock import patch, MagicMock
+from mock import mock, patch, MagicMock
 from neo.Network.neonetwork.network.nodemanager import NodeManager
 from neo.Network.neonetwork.network.node import NeoNode
+from neo.Network.neonetwork.common.singleton import Singleton
+from io import StringIO
 
 
 class CommandShowTestCase(BlockchainFixtureTestCase):
@@ -152,13 +154,20 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
         self.assertIn("1025", res)
         nodemgr.reset_for_test()
 
-    def test_show_state(self):
+    @mock.patch('neo.Prompt.Commands.Show.SyncManager')
+    def test_show_state(self, mock_SyncManager):
         # setup
+        class mock_SM(Singleton):
+            def init(self):
+                self.block_cache = [1, 2, 3, 4, 5]  # simulate blocks in the block_cache
+        mock_SyncManager.return_value = mock_SM()
         PromptInterface()
 
-        args = ['state']
-        res = CommandShow().execute(args)
-        self.assertTrue(res)
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['state']
+            res = CommandShow().execute(args)
+            self.assertTrue(res)
+            self.assertIn("Block-cache length 5", mock_print.getvalue())
 
     def test_show_notifications(self):
         # setup


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- currently "Block-cache length" only displays zero
- this fix displays the actual value

- originally from https://github.com/ixje/neo-python/pull/7
- supports https://github.com/CityOfZion/neo-python/pull/934

**How did you solve this problem?**
trial and error

**How did you make sure your solution works?**
`make test`

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
