### PR TITLE
improve user input for prompt with DEBUG output [2]

### DIFF
--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -184,8 +184,21 @@ class PromptInterface:
                 # Control-D pressed: quit
                 return self.quit()
             except KeyboardInterrupt:
-                # Control-C pressed: do nothing
-                continue
+                # Control-C pressed: pause for user input
+
+                # temporarily mute stdout during user input
+                # components like `network` set at DEBUG level will spam through the console
+                # making it impractical to input user data
+                log_manager.mute_stdio()
+
+                print('Logging output muted during user input...')
+                try:
+                    result = await session.prompt(async_=True)
+                except Exception as e:
+                    logger.error("Exception handling input: %s " % e)
+
+                # and re-enable stdio
+                log_manager.unmute_stdio()
             except Exception as e:
                 logger.error("Exception handling input: %s " % e)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- instead of doing nothing, KeyboardInterrupt now mutes stdout while the user inputs a command
- this is especially useful while `config output` includes any DEBUG setting

- originally from https://github.com/ixje/neo-python/pull/6
- supports https://github.com/CityOfZion/neo-python/pull/934

**How did you solve this problem?**
took cuing from `config output`

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
