### PR TITLE
add minpeers features

### DIFF
--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -19,6 +19,7 @@ class CommandConfig(CommandBase):
         self.register_sub_command(CommandConfigDebugNotify())
         self.register_sub_command(CommandConfigVMLog())
         self.register_sub_command(CommandConfigMaxpeers())
+        self.register_sub_command(CommandConfigMinpeers())
         self.register_sub_command(CommandConfigNEP8())
 
     def command_desc(self):
@@ -201,6 +202,33 @@ class CommandConfigMaxpeers(CommandBase):
     def command_desc(self):
         p1 = ParameterDesc('number', 'maximum number of nodes to connect to')
         return CommandDesc('maxpeers', 'configure number of max peers', [p1])
+
+
+class CommandConfigMinpeers(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        c1 = get_arg(arguments)
+        if c1 is not None:
+            try:
+                c1 = int(c1)
+                if c1 > settings.CONNECTED_PEER_MAX:
+                    print('minpeers setting cannot be bigger than maxpeers setting')
+                    return
+                settings.set_min_peers(c1)
+            except ValueError:
+                print("Please supply a positive integer for minpeers")
+                return
+            print(f"Minpeers set to {c1}")
+            return c1
+        else:
+            print(f"Maintaining minpeers at {settings.CONNECTED_PEER_MIN}")
+            return
+
+    def command_desc(self):
+        p1 = ParameterDesc('number', 'minimum number of nodes to connect to')
+        return CommandDesc('minpeers', 'configure number of min peers', [p1])
 
 
 def start_output_config():

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -142,6 +142,43 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
             self.assertFalse(res)
             self.assertIn("Please supply a positive integer for maxpeers", mock_print.getvalue())
 
+    def test_config_minpeers(self):
+        # test no input and verify output confirming current minpeers
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['minpeers']
+            res = CommandConfig().execute(args)
+            self.assertFalse(res)
+            self.assertIn(f"Maintaining minpeers at {settings.CONNECTED_PEER_MIN}", mock_print.getvalue())
+
+        # test changing the number of minpeers
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['minpeers', "6"]
+            res = CommandConfig().execute(args)
+            self.assertTrue(res)
+            self.assertEqual(int(res), settings.CONNECTED_PEER_MIN)
+            self.assertIn(f"Minpeers set to {settings.CONNECTED_PEER_MIN}", mock_print.getvalue())
+
+        # test bad input
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['minpeers', "blah"]
+            res = CommandConfig().execute(args)
+            self.assertFalse(res)
+            self.assertIn("Please supply a positive integer for minpeers", mock_print.getvalue())
+
+        # test negative number
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['minpeers', "-1"]
+            res = CommandConfig().execute(args)
+            self.assertFalse(res)
+            self.assertIn("Please supply a positive integer for minpeers", mock_print.getvalue())
+
+        # test minpeers greater than maxpeers
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['minpeers', f"{settings.CONNECTED_PEER_MAX + 1}"]
+            res = CommandConfig().execute(args)
+            self.assertFalse(res)
+            self.assertIn("minpeers setting cannot be bigger than maxpeers setting", mock_print.getvalue())
+
     def test_config_nep8(self):
         # test with missing flag argument
         with patch('sys.stdout', new=StringIO()) as mock_print:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- adds `config minpeers` and tests
- prompt now mirrors api_server logic for minpeers & maxpeers

- supports https://github.com/CityOfZion/neo-python/pull/934

**How did you solve this problem?**
trial and error

**How did you make sure your solution works?**
`make test` and manual testing with privatenet

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
