### PR TITLE
fixes `wallet verbose`

### DIFF
--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -190,8 +190,9 @@ class CommandWalletVerbose(CommandBase):
         super().__init__()
 
     def execute(self, arguments=None):
-        print("Wallet %s " % json.dumps(PromptData.Wallet.ToJson(verbose=True), indent=4))
-        return True
+        wallet = PromptData.Wallet
+        wallet.pretty_print(verbose=True)
+        return wallet
 
     def command_desc(self):
         return CommandDesc('verbose', 'show additional wallet details')

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -61,7 +61,7 @@ class CommandWallet(CommandBase):
             print("Please open a wallet")
             return
 
-        if not item or item == 'verbose':
+        if not item:
             wallet.pretty_print(item)
             return wallet
 

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -256,28 +256,32 @@ class UserWalletTestCase(UserWalletTestCaseBase):
             args = ['']
             res = CommandWallet().execute(args)
             self.assertTrue(res)
-            self.assertNotIn("transactions", mock_print.getvalue())
+            self.assertNotIn("Script hash", mock_print.getvalue())
+            self.assertNotIn("Public key", mock_print.getvalue())
 
         # now test wallet verbose with open wallet
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['verbose']
             res = CommandWallet().execute(args)
             self.assertTrue(res)
-            self.assertIn("transactions", mock_print.getvalue())
+            self.assertIn("Script hash", mock_print.getvalue())
+            self.assertIn("Public key", mock_print.getvalue())
 
         # also test "v"
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['v']
             res = CommandWallet().execute(args)
             self.assertTrue(res)
-            self.assertIn("transactions", mock_print.getvalue())
+            self.assertIn("Script hash", mock_print.getvalue())
+            self.assertIn("Public key", mock_print.getvalue())
 
         # and "--v"
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['--v']
             res = CommandWallet().execute(args)
             self.assertTrue(res)
-            self.assertIn("transactions", mock_print.getvalue())
+            self.assertIn("Script hash", mock_print.getvalue())
+            self.assertIn("Public key", mock_print.getvalue())
 
     def test_wallet_claim_1(self):
         # test with no wallet

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -251,10 +251,33 @@ class UserWalletTestCase(UserWalletTestCaseBase):
 
         self.OpenWallet1()
 
-        # test wallet close with open wallet
-        args = ['verbose']
-        res = CommandWallet().execute(args)
-        self.assertTrue(res)
+        # first test normal wallet printing
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['']
+            res = CommandWallet().execute(args)
+            self.assertTrue(res)
+            self.assertNotIn("transactions", mock_print.getvalue())
+
+        # now test wallet verbose with open wallet
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['verbose']
+            res = CommandWallet().execute(args)
+            self.assertTrue(res)
+            self.assertIn("transactions", mock_print.getvalue())
+
+        # also test "v"
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['v']
+            res = CommandWallet().execute(args)
+            self.assertTrue(res)
+            self.assertIn("transactions", mock_print.getvalue())
+
+        # and "--v"
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['--v']
+            res = CommandWallet().execute(args)
+            self.assertTrue(res)
+            self.assertIn("transactions", mock_print.getvalue())
 
     def test_wallet_claim_1(self):
         # test with no wallet

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -142,6 +142,7 @@ class PromptInterface:
     def quit(self):
         print('Shutting down. This may take a bit...')
         self.go_on = False
+        PromptData.close_wallet()
         raise SystemExit
 
     def help(self):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- previously only "pretty printed" if "verbose", didn't actually complete the command

- supports https://github.com/CityOfZion/neo-python/pull/934

**How did you solve this problem?**
- now only "pretty prints" for simple "wallet" query
  -edit-
  now "pretty prints" as expected
- fixed the tests to verify expected behavior

- separately, now closes the wallet when exiting a prompt session (not sure why it was removed as I think this is reassuring to the user)

**How did you make sure your solution works?**
`make test` and manual testing for closing the wallet on "exit"

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
