### PR TITLE
Update build_run test

### DIFF
--- a/neo/Prompt/Commands/tests/test_sc_commands.py
+++ b/neo/Prompt/Commands/tests/test_sc_commands.py
@@ -137,14 +137,14 @@ class CommandSCTestCase(WalletFixtureTestCase):
             self.assertIn("Test deploy invoke successful", mock_print.getvalue())
 
         # test successful build and run with prompted input
-        # PromptData.Wallet = self.GetWallet1(recreate=True)
-        # with patch('sys.stdout', new=StringIO()) as mock_print:
-        #     with patch('neo.Prompt.Utils.PromptSession.prompt', side_effect=['remove', 'AG4GfwjnvydAZodm4xEDivguCtjCFzLcJy', '3']):
-        #         args = ['build_run', 'neo/Prompt/Commands/tests/SampleSC.py', 'True', 'False', 'False', '070502', '02', '--i']
-        #         tx, result, total_ops, engine = CommandSC().execute(args)
-        #         self.assertTrue(tx)
-        #         self.assertEqual(str(result[0]), '0')
-        #         self.assertIn("Test deploy invoke successful", mock_print.getvalue())
+        PromptData.Wallet = self.GetWallet1(recreate=True)
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            with patch('neo.Prompt.Utils.prompt', side_effect=['remove', 'AG4GfwjnvydAZodm4xEDivguCtjCFzLcJy', '3']):
+                args = ['build_run', 'neo/Prompt/Commands/tests/SampleSC.py', 'True', 'False', 'False', '070502', '02', '--i']
+                tx, result, total_ops, engine = CommandSC().execute(args)
+                self.assertTrue(tx)
+                self.assertEqual(str(result[0]), '0')
+                self.assertIn("Test deploy invoke successful", mock_print.getvalue())
 
         # test invoke failure (SampleSC requires three inputs)
         PromptData.Wallet = self.GetWallet1(recreate=True)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
updates the `build_run` test to incorporate the changes from https://github.com/CityOfZion/neo-python/pull/934/commits/cf2fa02e89da04a5fdc4ef845598ee8cb212efbe

supports https://github.com/CityOfZion/neo-python/pull/934

**How did you solve this problem?**
Originally, this test was commented out and I'm not sure why.
I uncommented it and then updated it for the changes from the commit above.

**How did you make sure your solution works?**
`make test`

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
